### PR TITLE
Benvigllow

### DIFF
--- a/OW_Scoreboard_Tool/Form1.cs
+++ b/OW_Scoreboard_Tool/Form1.cs
@@ -1512,6 +1512,7 @@ namespace OW_Scoreboard_Tool
                 {
                     loadingText = File.ReadAllText(path + "\\" + folder + "\\" + file + "Gametype" + ".txt");
                 }
+
                 Console.Out.WriteLine("This is the loaded text: " + loadingText);
                 field.SelectedIndex = field.FindString(loadingText.Trim());
                 Console.Out.WriteLine("This is the index: " + field.SelectedIndex);

--- a/OW_Scoreboard_Tool/Form1.cs
+++ b/OW_Scoreboard_Tool/Form1.cs
@@ -1481,31 +1481,41 @@ namespace OW_Scoreboard_Tool
 
         private void loadText(TextBox field, String folder, String file)
         {
-            string loadingText = File.ReadAllText(path + "\\" + folder + "\\" + file + ".txt");
-
-            field.Text = loadingText;
-            field.Text.Trim();
-
+            if (File.Exists(path + "\\" + folder + "\\" + file + ".txt"))
+            {
+                string loadingText = File.ReadAllText(path + "\\" + folder + "\\" + file + ".txt");
+                field.Text = loadingText;
+                field.Text.Trim();
+            }
 
         }
 
         private void loadScore(NumericUpDown field, String folder, String file)
         {
-            string loadingText = File.ReadAllText(path + "\\" + folder + "\\" + file + ".txt");
-            decimal number;
-            Decimal.TryParse(loadingText, out number);
-            field.Value = number; 
-
+            if (File.Exists(path + "\\" + folder + "\\" + file + ".txt"))
+            {
+                string loadingText = File.ReadAllText(path + "\\" + folder + "\\" + file + ".txt");
+                decimal number;
+                Decimal.TryParse(loadingText, out number);
+                field.Value = number;
+            }
 
         }
 
         private void loadCombo(ComboBox field, String folder, String file)
-        {
-            string loadingText = File.ReadAllText(path + "\\" + folder + "\\" + file + ".txt");
-            Console.Out.WriteLine("This is the loaded text: " + loadingText);
-            field.SelectedIndex = field.FindString(loadingText.Trim());
-            Console.Out.WriteLine("This is the index: " + field.SelectedIndex);
-
+            {
+            if (File.Exists(path + "\\" + folder + "\\" + file + ".txt"))
+            {
+                string loadingText = File.ReadAllText(path + "\\" + folder + "\\" + file + ".txt");
+                Console.Out.WriteLine(file.Substring(2, 3));
+                if (loadingText.Trim() == "?" && file.Substring(2, 3) == "Map")
+                {
+                    loadingText = File.ReadAllText(path + "\\" + folder + "\\" + file + "Gametype" + ".txt");
+                }
+                Console.Out.WriteLine("This is the loaded text: " + loadingText);
+                field.SelectedIndex = field.FindString(loadingText.Trim());
+                Console.Out.WriteLine("This is the index: " + field.SelectedIndex);
+            }
         }
 
         private void resetText(TextBox field)


### PR DESCRIPTION
Fixed  2 errors.
The first fix is a check that allows the application to still load up if one of the files it pulls text from isn't there, so people aren't out of luck if the accidentally delete a file. 
The other fix fixes the map combo box loading game types. I found that if I had a game type in one of them, it wouldn't load back in. This is fixed now.